### PR TITLE
Add functionality for building promises from Qt signals

### DIFF
--- a/docs/qtpromise/qtsignals.md
+++ b/docs/qtpromise/qtsignals.md
@@ -1,0 +1,32 @@
+## Creating `QPromise<T>` from signals
+
+When creating promises from from signals, care must be taken to guarantee that all signals involved in the promise creation are disconnected after fulfillment.
+
+The easiest option is to simply delete the signal source after the promise is handled:
+```cpp
+// in promise returning method
+return QPromise<void>([&](const auto& resolve, const auto& reject) {
+    QObject::connect(obj, &Object::signal, [=]() {
+        // {... resolve/reject ...}
+        object->deleteLater();
+    });
+});
+```
+
+Sometimes the deletion of the signal source may not be possible. In this case, all signal connections must be tracked and disconnected manually. QtPromise provides the `QPromiseConnections` helper to handle this conveniently:
+```cpp
+// in promise returning method
+QPromiseConnections connections;
+return QPromise<void>([&](const auto& resolve, const auto& reject) {
+    connections << QObject::connect(obj1, &Object::signal1, [=]() {
+        // {... resolve/reject ...}
+    });
+    connections << QObject::connect(obj2, &Object::signal2, [=]() {
+        // {... resolve/reject ...}
+    });
+})
+// timeout in case no signals are emitted at all
+.timeout(2000)
+// clean up signal connections when finished
+.finally([=]() { connections.disconnect(); });
+```

--- a/docs/qtpromise/qtsignals.md
+++ b/docs/qtpromise/qtsignals.md
@@ -23,25 +23,15 @@ p.then([](const QString& value) {
 ```
 `QPromise<void>` is created for signals with no arguments.
 
-A rejection is added to the promise by providing a second signal:
+A rejection is added to the promise by providing a second signal.
+Rejections from signals are caught by `QPromiseSignalException<T>`:
 ```cpp
 // void intRejectSignal(int)
 QPromise<void> p = QtPromise::connect(
     obj, &Object::voidResolveSignal, &Object::intRejectSignal,
 );
-p.fail([](int value) {
-    // rejected with `value` from intRejectSignal
-});
-```
-
-Rejections from signals with no arguments are caught by `QPromiseSignalException`:
-```cpp
-// void voidRejectSignal()
-QPromise<void> p = QtPromise::connect(
-    obj, &Object::voidResolveSignal, &Object::voidRejectSignal
-);
-p.fail([](const QPromiseSignalException&) {
-    // rejected by voidRejectSignal
+p.fail([](const QPromiseSignalException<int>& e) {
+    // rejected with `e.value` from intRejectSignal
 });
 ```
 
@@ -53,6 +43,9 @@ QPromise<void> p = QtPromise::connect(
 );
 p.then([]() {
     // promise fulfilled
+}).fail([](const QPromiseSignalException<void>&) {
+    // rejected by voidResolveSignal
+}
 }).fail([](const QPromiseContextException&) {
     // rejected by obj destruction
 });

--- a/include/QtPromise
+++ b/include/QtPromise
@@ -3,6 +3,7 @@
 
 #include "../src/qtpromise/qpromise.h"
 #include "../src/qtpromise/qpromisefuture.h"
+#include "../src/qtpromise/qpromisesignals.h"
 #include "../src/qtpromise/qpromisehelpers.h"
 
 #endif // ifndef QTPROMISE_MODULE_H

--- a/src/qtpromise/qpromiseerror.h
+++ b/src/qtpromise/qpromiseerror.h
@@ -31,7 +31,17 @@ class QPromiseTimeoutException : public QtPromisePrivate::ExceptionBase<QPromise
 class QPromiseContextException : public QtPromisePrivate::ExceptionBase<QPromiseContextException>
 { };
 
-class QPromiseSignalException : public QtPromisePrivate::ExceptionBase<QPromiseSignalException>
+template <typename T>
+class QPromiseSignalException : public QtPromisePrivate::ExceptionBase<QPromiseSignalException<T>>
+{
+public:
+    template <typename V>
+    QPromiseSignalException(V&& v) : value(std::forward<V>(v)) { }
+    const T value;
+};
+
+template<>
+class QPromiseSignalException<void> : public QtPromisePrivate::ExceptionBase<QPromiseSignalException<void>>
 { };
 
 // QPromiseError is provided for backward compatibility and will be

--- a/src/qtpromise/qpromiseerror.h
+++ b/src/qtpromise/qpromiseerror.h
@@ -8,17 +8,31 @@
 // Qt
 #include <QException>
 
-namespace QtPromise {
+namespace QtPromisePrivate {
 
-class QPromiseTimeoutException : public QException
+template <typename T>
+class ExceptionBase : public QException
 {
 public:
     void raise() const Q_DECL_OVERRIDE { throw *this; }
-    QPromiseTimeoutException* clone() const Q_DECL_OVERRIDE
+    QException* clone() const Q_DECL_OVERRIDE
     {
-        return new QPromiseTimeoutException(*this);
+        return new T(*reinterpret_cast<const T*>(this));
     }
 };
+
+} // namespace QtPromisePrivate
+
+namespace QtPromise {
+
+class QPromiseTimeoutException : public QtPromisePrivate::ExceptionBase<QPromiseTimeoutException>
+{ };
+
+class QPromiseContextException : public QtPromisePrivate::ExceptionBase<QPromiseContextException>
+{ };
+
+class QPromiseSignalException : public QtPromisePrivate::ExceptionBase<QPromiseSignalException>
+{ };
 
 // QPromiseError is provided for backward compatibility and will be
 // removed in the next major version: it wasn't intended to be used

--- a/src/qtpromise/qpromisesignals.h
+++ b/src/qtpromise/qpromisesignals.h
@@ -1,0 +1,44 @@
+#ifndef QTPROMISE_QPROMISESIGNALS_H
+#define QTPROMISE_QPROMISESIGNALS_H
+
+#include <QObject>
+#include <memory>
+#include "qpromise.h"
+
+
+namespace QtPromise {
+
+class QPromiseConnections : private std::shared_ptr<std::vector<QMetaObject::Connection>>
+{
+    using Connections = std::vector<QMetaObject::Connection>;
+    using Base = std::shared_ptr<Connections>;
+
+public:
+    QPromiseConnections() : Base(new Connections, [](Connections* c) {
+        if (!c->empty()) {
+            qWarning("QPromiseConnections: destroyed with unhandled connections");
+            disconnectConnections(c);
+        }
+        delete c;
+    }) { }
+
+    void operator<<(QMetaObject::Connection&& other) const
+    {
+        get()->emplace_back(std::move(other));
+    }
+
+    size_t count() const { return get()->size(); }
+
+    void disconnect() const { disconnectConnections(get()); }
+
+private:
+    static void disconnectConnections(Connections* c) Q_DECL_NOEXCEPT
+    {
+        for (const auto& connection: *c) { QObject::disconnect(connection); }
+        c->clear();
+    }
+};
+
+} // namespace QtPromise
+
+#endif // QTPROMISE_QPROMISESIGNALS_H

--- a/src/qtpromise/qpromisesignals.h
+++ b/src/qtpromise/qpromisesignals.h
@@ -41,4 +41,109 @@ private:
 
 } // namespace QtPromise
 
+namespace QtPromisePrivate {
+
+// Deduce promise types from Qt signals
+// TODO: Suppress QPrivateSignal trailing private signal args
+// TODO: Support deducing tuple from args (might require MSVC2017)
+template <typename Signal>
+using PromiseFromSignal = typename QtPromise::QPromise<Unqualified<typename ArgsOf<Signal>::first>>;
+
+// Connect signal() to QPromiseResolve
+template <typename Sender, typename Signal>
+typename std::enable_if<(ArgsOf<Signal>::count == 0)>::type
+connectSignalToResolver(const QtPromise::QPromiseConnections& connections,
+                        const QtPromise::QPromiseResolve<void>& resolve,
+                        const Sender* sender, Signal signal)
+{
+    connections << QObject::connect(sender, signal, [=]() {
+        resolve();
+        connections.disconnect();
+    });
+}
+
+// Connect signal() to QPromiseReject
+template <typename Reason = QtPromise::QPromiseSignalException,
+          typename T, typename Sender, typename Signal>
+typename std::enable_if<(ArgsOf<Signal>::count == 0)>::type
+connectSignalToResolver(const QtPromise::QPromiseConnections& connections,
+                        const QtPromise::QPromiseReject<T>& reject,
+                        const Sender* sender, Signal signal)
+{
+    connections << QObject::connect(sender, signal, [=]() {
+        reject(Reason());
+        connections.disconnect();
+    });
+}
+
+// Connect signal(args...) to QPromiseResolve or QPromiseReject
+template <typename Resolver, typename Sender, typename Signal>
+typename std::enable_if<(ArgsOf<Signal>::count >= 1)>::type
+connectSignalToResolver(const QtPromise::QPromiseConnections& connections,
+                        const Resolver& resolver,
+                        const Sender* sender, Signal signal)
+{
+    using V = typename ArgsOf<Signal>::first;
+    connections << QObject::connect(sender, signal, [=](const V& value) {
+        resolver(value);
+        connections.disconnect();
+    });
+}
+
+// Connect QObject::destroyed signal to QPromiseReject
+template <typename T, typename Sender>
+void connectDestroyedToReject(const QtPromise::QPromiseConnections& connections,
+                              const QtPromise::QPromiseReject<T>& reject,
+                              const Sender* sender)
+{
+    connections << QObject::connect(sender, &QObject::destroyed, [=]() {
+        reject(QtPromise::QPromiseContextException());
+        connections.disconnect();
+    });
+}
+
+} // namespace QtPromisePrivate
+
+namespace QtPromise {
+
+template <typename Sender, typename Signal>
+static inline typename QtPromisePrivate::PromiseFromSignal<Signal>
+connect(const Sender* sender, Signal signal)
+{
+    using T = typename QtPromisePrivate::PromiseFromSignal<Signal>::Type;
+    using QtPromisePrivate::connectSignalToResolver;
+
+    return QPromise<T>([&](const QPromiseResolve<T>& resolve,
+                           const QPromiseReject<T>& reject) {
+        QPromiseConnections connections;
+        connectSignalToResolver(connections, resolve, sender, signal);
+        QtPromisePrivate::connectDestroyedToReject(connections, reject, sender);
+    });
+}
+
+template <typename FSender, typename FSignal, typename RSender, typename RSignal>
+static inline typename QtPromisePrivate::PromiseFromSignal<FSignal>
+connect(const FSender* fsender, FSignal fsignal, const RSender* rsender, RSignal rsignal)
+{
+    using T = typename QtPromisePrivate::PromiseFromSignal<FSignal>::Type;
+    using QtPromisePrivate::connectSignalToResolver;
+
+    return QPromise<T>([&](const QPromiseResolve<T>& resolve,
+                           const QPromiseReject<T>& reject) {
+        QPromiseConnections connections;
+        connectSignalToResolver(connections, resolve, fsender, fsignal);
+        connectSignalToResolver(connections, reject, rsender, rsignal);
+        QtPromisePrivate::connectDestroyedToReject(connections, reject, fsender);
+    });
+}
+
+template <typename Sender, typename FSignal, typename RSignal>
+static inline typename QtPromisePrivate::PromiseFromSignal<FSignal>
+connect(const Sender* sender, FSignal fsignal, RSignal rsignal)
+{
+    return connect(sender, fsignal, sender, rsignal);
+}
+
+} // namespace QtPromise
+
 #endif // QTPROMISE_QPROMISESIGNALS_H

--- a/src/qtpromise/qtpromise.pri
+++ b/src/qtpromise/qtpromise.pri
@@ -6,4 +6,5 @@ HEADERS += \
     $$PWD/qpromisefuture.h \
     $$PWD/qpromiseglobal.h \
     $$PWD/qpromisehelpers.h \
-    $$PWD/qpromiseresolver.h
+    $$PWD/qpromiseresolver.h \
+    $$PWD/qpromisesignals.h

--- a/tests/auto/qtpromise/qtpromise.pro
+++ b/tests/auto/qtpromise/qtpromise.pro
@@ -2,6 +2,7 @@ TEMPLATE = subdirs
 SUBDIRS += \
     benchmark \
     future \
+    signals \
     helpers \
     qpromise \
     requirements \

--- a/tests/auto/qtpromise/signals/signals.pro
+++ b/tests/auto/qtpromise/signals/signals.pro
@@ -1,0 +1,4 @@
+TARGET = tst_signals
+SOURCES += $$PWD/tst_signals.cpp
+
+include(../qtpromise.pri)

--- a/tests/auto/qtpromise/signals/tst_signals.cpp
+++ b/tests/auto/qtpromise/signals/tst_signals.cpp
@@ -98,7 +98,9 @@ void tst_signals::reject()
     const QString testValue("42");
     QString reason;
     emit signalSource.strSignal(testValue);
-    p.fail([&](const QString& r) { reason = r; }).wait();
+    p.fail([&](const QtPromise::QPromiseSignalException<QString>& r) {
+        reason = r.value;
+    }).wait();
 
     QVERIFY(p.isRejected());
     QVERIFY(reason == testValue);
@@ -116,7 +118,7 @@ void tst_signals::reject_void()
 
     emit signalSource.voidSignal();
     bool result = false;
-    p.fail([&](const QPromiseSignalException&) { result = true; return 0; }).wait();
+    p.fail([&](const QtPromise::QPromiseSignalException<void>&) { result = true; return 0; }).wait();
 
     QVERIFY(p.isRejected());
     QVERIFY(result);

--- a/tests/auto/qtpromise/signals/tst_signals.cpp
+++ b/tests/auto/qtpromise/signals/tst_signals.cpp
@@ -1,0 +1,83 @@
+#include <QString>
+#include <QtTest>
+
+// QtPromise
+#include <QtPromise>
+
+// Qt
+#include <QtTest>
+
+using namespace QtPromise;
+
+class tst_signals : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void signalSource();
+    void promiseConnections();
+
+}; // class tst_signals
+
+
+// Test class for emitting signals and checking connections
+class SignalSource : public QObject
+{
+    Q_OBJECT
+
+public:
+    // Return true if listeners are connected to signals
+    bool hasConnectedSignals() const { return m_connections > 0; }
+
+signals:
+    void voidSignal();
+    void intSignal(int value);
+
+protected:
+    int m_connections = 0;
+    void connectNotify(const QMetaMethod&) override { ++m_connections; }
+    void disconnectNotify(const QMetaMethod&) override { --m_connections; }
+};
+
+QTEST_MAIN(tst_signals)
+#include "tst_signals.moc"
+
+
+void tst_signals::signalSource()
+{
+    // Check if SignalSource is aware of connected signal handlers
+    SignalSource signalSource;
+    QVERIFY(!signalSource.hasConnectedSignals());
+    auto c = connect(&signalSource, &SignalSource::voidSignal, [](){});
+    QVERIFY(signalSource.hasConnectedSignals());
+    disconnect(c);
+    QVERIFY(!signalSource.hasConnectedSignals());
+}
+
+void tst_signals::promiseConnections()
+{
+    SignalSource source;
+    // Track and disconnect signals with QPromiseConnections
+    {
+        QPromiseConnections connections;
+        connections << connect(&source, &SignalSource::intSignal, [=]() {
+            connections.disconnect();
+        });
+        connections << connect(&source, &SignalSource::voidSignal, [=]() {
+            connections.disconnect();
+        });
+        QVERIFY(connections.count() == 2);
+        QVERIFY(source.hasConnectedSignals());
+
+        emit source.voidSignal();
+        QVERIFY(connections.count() == 0);
+        QVERIFY(!source.hasConnectedSignals());
+    }
+    // Disconnect on destruction
+    {
+        QPromiseConnections connections;
+        connections << connect(&source, &SignalSource::intSignal, []() {});
+        QVERIFY(source.hasConnectedSignals());
+    }
+    QVERIFY(!source.hasConnectedSignals());
+}


### PR DESCRIPTION
Here is my first code drop implementing helper methods for building promises from Qt signals.

There is already something that got me puzzled during implementation. `QPromiseReject` must be called with a value, but rejection signals could be `void`. What to do in this case?

At the moment there is:
```qPromise(QObject* fulfiller, F fsignal, QObject* rejecter, R rsignal)```

Maybe add another method like this
```qPromise(QObject* fulfiller, F fsignal, QObject* rejecter, R rsignal, Reason&& reason)```
that ignores the value from the rejection signal and passes `reason` on to `QPromiseReject` instead?