### PR TITLE
Update travis environment, use Qt 5.6 as minimum requirement (#16)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,15 @@ language: cpp
 compiler: gcc
 
 before_install:
-  - sudo add-apt-repository -y ppa:beineri/opt-qt542-trusty
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo add-apt-repository -y ppa:beineri/opt-qt563-trusty
   - sudo apt-get update -qq
 
 install:
-  - sudo apt-get install -qq qt54base
-  - source /opt/qt54/bin/qt54-env.sh
+  - sudo apt-get install -qq gcc-4.9 g++-4.9
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
+  - sudo apt-get install -qq qt56base
+  - source /opt/qt56/bin/qt56-env.sh
   - wget http://archive.ubuntu.com/ubuntu/pool/universe/l/lcov/lcov_1.13.orig.tar.gz
   - tar xf lcov_1.13.orig.tar.gz
   - cd lcov-1.13/
@@ -19,7 +22,7 @@ install:
 before_script:
   - qmake --version
   - lcov --version
-  - gcc --version
+  - gcc --version && g++ --version
 
 script:
   - qmake qtpromise.pro CONFIG+=coverage

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [Promises/A+](https://promisesaplus.com/) implementation for [Qt/C++](https://www.qt.io/).
 
-Requires [Qt 5.4](https://www.qt.io/download/) (or later) with [C++11 support enabled](https://wiki.qt.io/How_to_use_C++11_in_your_Qt_Projects).
+Requires [Qt 5.6](https://www.qt.io/download/) (or later) with [C++11 support enabled](https://wiki.qt.io/How_to_use_C++11_in_your_Qt_Projects).
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 # QtPromise
 [Promises/A+](https://promisesaplus.com/) implementation for [Qt/C++](https://www.qt.io/).
 
-Requires [Qt 5.4](https://www.qt.io/download/) (or later) with [C++11 support enabled](https://wiki.qt.io/How_to_use_C++11_in_your_Qt_Projects).
+Requires [Qt 5.6](https://www.qt.io/download/) (or later) with [C++11 support enabled](https://wiki.qt.io/How_to_use_C++11_in_your_Qt_Projects).
 
 ## QtPromise for C++
 * [Getting Started](qtpromise/getting-started.md)

--- a/tests/auto/qtpromise/qpromise/timeout/tst_timeout.cpp
+++ b/tests/auto/qtpromise/qpromise/timeout/tst_timeout.cpp
@@ -87,6 +87,9 @@ void tst_qpromise_timeout::timeout()
     QCOMPARE(waitForValue(p, -1), -1);
     QCOMPARE(p.isRejected(), true);
     QCOMPARE(failed, true);
-    QVERIFY(elapsed >= 2000 * 0.95);    // Qt::CoarseTimer (default) Coarse timers try to
-    QVERIFY(elapsed <= 2000 * 1.05);    // keep accuracy within 5% of the desired interval.
+    // Qt::CoarseTimer (default) Coarse timers try to
+    // keep accuracy within 5% of the desired interval.
+    // Require accuracy within 6% for passing the test.
+    QVERIFY(elapsed >= 2000 * 0.94);
+    QVERIFY(elapsed <= 2000 * 1.06);
 }


### PR DESCRIPTION
This PR updates the test environment in TravisCI / Ubuntu 14.04 to Qt 5.6 and GCC 4.9 for fixing various bugs present in earlier versions. The documentation now also mentions Qt 5.6 as the minimum required (i.e. tested) version.

The new environment did randomly fail however due to the very hard timing constraint in `tst_timeout`. The test was a fail due to random violations of 1 or 2 milliseconds. I relaxed the timing constraints a bit.