### PR TITLE
Add AppVeyor configuration file for running MSVC tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,22 @@
+image: Visual Studio 2015
+
+init:
+  - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio "%VSVER%".0\VC\vcvarsall.bat" %ARCH%
+
+environment:
+  PATH: '%PATH%;%QTDIR%\bin'
+  matrix:
+    - QTDIR: C:\Qt\5.6\msvc2013
+      VSVER: 12
+      ARCH: x86
+    - QTDIR: C:\Qt\5.9\msvc2013_64
+      VSVER: 12
+      ARCH: x64
+
+build_script:
+  - cmd: qmake qtpromise.pro
+  - cmd: nmake
+
+test_script:
+  - cmd: nmake check
+


### PR DESCRIPTION
I was looking for a way to modify and test Pull Requests without flooding you with superfluous notifications, so I ended up enabling automated tests for my GitHub clone too. This works out of the box with TravisCI, but since there is no AppVeyor configuration file I had to set up the MSVC tests manually.

This PR is a proposal for defining the automated tests by configuration file within the repository. I set up a new `.appveyor.yml` for testing Qt 5.6 and Qt 5.9 on the default AppVeyor image. The only manual step in enabling tests now is to set the default configuration name to `.appveyor.yml` on the AppVeyor settings page.