### PR TITLE
More verbose description of throwing an exception from a QtConcurrent thread

### DIFF
--- a/docs/qtpromise/getting-started.md
+++ b/docs/qtpromise/getting-started.md
@@ -206,3 +206,6 @@ download(url).then(&uncompress).then([](const Entries& entries) {
     // {...} catch all
 });
 ```
+
+Note that `MalformedException` in the example above is thrown from a QtConcurrent thread and should 
+meet [specific conditions](qtconcurrent.md#error).


### PR DESCRIPTION
Hey Simon, 

I've stumbled upon a small issue today when throwing an exception from a QtConcurrent::run() call. My program didn't go into fail() when the exception was thrown, and I spent some time on it. So I looked into the QtPromise docs first and saw that the exception should be a QException subclass, which my exception was, but it still didn't work. So after a bit of debugging, I looked into the auto tests of QtPromise and saw that the methods `clone()` and `raise()` are overriden. And only after that I went to the Qt docs and saw that this has to be done to subclass the QException correctly.

I propose the following change to QtPromise docs. This should make it more obvious that the QException subclasses should override those two methods. Although this basically repeats the Qt docs, I think it's worth pointing out since not everybody throws from QtConcurrent on a daily basis :)

Cheers
Dmitriy