### PR TITLE
Fix deprecations and compile warnings

### DIFF
--- a/src/qtpromise/qpromiseconnections.h
+++ b/src/qtpromise/qpromiseconnections.h
@@ -8,14 +8,15 @@
 #ifndef QTPROMISE_QPROMISECONNECTIONS_H
 #define QTPROMISE_QPROMISECONNECTIONS_H
 
-#include <QtCore/QSharedPointer>
+#include <QtCore/QObject>
+#include <memory>
 
 namespace QtPromise {
 
 class QPromiseConnections
 {
 public:
-    QPromiseConnections() : m_d(QSharedPointer<Data>::create()) { }
+    QPromiseConnections() : m_d(std::make_shared<Data>()) { }
 
     int count() const { return m_d->connections.count(); }
 
@@ -48,7 +49,7 @@ private:
         }
     };
 
-    QSharedPointer<Data> m_d;
+    std::shared_ptr<Data> m_d;
 };
 
 } // namespace QtPromise

--- a/src/qtpromise/qpromisehelpers.h
+++ b/src/qtpromise/qpromisehelpers.h
@@ -32,7 +32,7 @@ static inline typename QtPromisePrivate::PromiseDeduce<T>::Type resolve(T&& valu
 template<typename T>
 static inline QPromise<T> resolve(QPromise<T> value)
 {
-    return std::move(value);
+    return value;
 }
 
 static inline QPromise<void> resolve()

--- a/tests/auto/qtpromise/helpers/tst_reduce.cpp
+++ b/tests/auto/qtpromise/helpers/tst_reduce.cpp
@@ -290,7 +290,10 @@ void tst_helpers_reduce::functorThrows()
 
 void tst_helpers_reduce::sequenceTypes()
 {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
+    // QLinkedList is deprecated since Qt 5.15.
     SequenceTester<QLinkedList<QPromise<int>>>::exec();
+#endif
     SequenceTester<QList<QPromise<int>>>::exec();
     SequenceTester<QVector<QPromise<int>>>::exec();
     SequenceTester<std::list<QPromise<int>>>::exec();

--- a/tests/auto/qtpromise/qpromise/tst_reduce.cpp
+++ b/tests/auto/qtpromise/qpromise/tst_reduce.cpp
@@ -283,7 +283,10 @@ void tst_qpromise_reduce::functorThrows()
 
 void tst_qpromise_reduce::sequenceTypes()
 {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
+    // QLinkedList is deprecated since Qt 5.15.
     SequenceTester<QLinkedList<QPromise<int>>>::exec();
+#endif
     SequenceTester<QList<QPromise<int>>>::exec();
     SequenceTester<QVector<QPromise<int>>>::exec();
     SequenceTester<std::list<QPromise<int>>>::exec();


### PR DESCRIPTION
Hi Simon,
after moving towards C++20, MSVC 2019 / GCC 9 and Qt 5.15 I found a few deprecation- and compiler-warnings.

- `std::result_of` is deprecated in C++17 and will be removed in C++20. MSVC2019 complains a lot about this. I replaced all occurrences with `std::invoke_result` and added a fallback when below C++17 (thanks for MSVC requiring extra work for the version check.. gah).
- Removed a redundant `std::move` that GCC complained about. Probably one of those cases where explicit move prevents a more optimized RVO.
- Removed tests against `QLinkedList`. Qt 5.15 now includes deprecation warnings advising against using `QLinkedList` in favor of `std::list` (if linked-list is you really want ofc.).
- `QSharedPointer` in Promise Connections causes GCC to raise uninitialized value warnings. I tried to throw in some `noexcept`s at the shared data definition, but I don't really know how to fix this. Using `std::shared_ptr` seems to be a better option here (no warnings, maintained in std, move support).