### PR TITLE
fix some clang/gcc warnings found integrating qtpromise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         -Wlogical-op
         -Wmissing-noreturn
         -Wold-style-cast
-        -Wshadow
+#        -Wshadow                   # disabled due to many findings in the current code
         -Wsign-conversion
         -Wswitch-default
         -Wunused-local-typedefs
-        -Wuseless-cast
+#        -Wuseless-cast             # disabled due to Qt's moc warnings
 
         -pedantic-errors
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 
         -Wconversion
         -Wdouble-promotion
-        -Wduplicated-branches
-        -Wduplicated-cond
         -Wformat=2
         -Wlogical-op
         -Wmissing-noreturn
@@ -50,6 +48,20 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 
         -pedantic-errors
     )
+
+    # https://github.com/Barro/compiler-warnings/blob/master/gcc/warnings-gcc-6.txt
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6)
+        add_compile_options(
+            -Wduplicated-cond
+        )
+    endif()
+
+    # https://github.com/Barro/compiler-warnings/blob/master/gcc/warnings-gcc-7.txt
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7)
+        add_compile_options(
+            -Wduplicated-branches
+        )
+    endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # https://clang.llvm.org/docs/DiagnosticsReference.html
     add_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,21 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         -Wpedantic
         -Wall
         -Wextra
+
         -Wconversion
+        -Wdouble-promotion
+        -Wduplicated-branches
+        -Wduplicated-cond
+        -Wformat=2
+        -Wlogical-op
+        -Wmissing-noreturn
+        -Wold-style-cast
         -Wshadow
         -Wsign-conversion
-        -Wold-style-cast
+        -Wswitch-default
         -Wunused-local-typedefs
+        -Wuseless-cast
+
         -pedantic-errors
     )
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,16 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         -Wunused-local-typedefs
         -pedantic-errors
     )
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # https://clang.llvm.org/docs/DiagnosticsReference.html
+    add_compile_options(
+        -Wall
+        -Wextra
+        -Wpedantic
+
+        -Wsuggest-destructor-override
+        -Wsuggest-override
+    )
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     # https://docs.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level
     add_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         -Wall
         -Wextra
         -Wconversion
+        -Wshadow
         -Wsign-conversion
         -Wold-style-cast
         -Wunused-local-typedefs

--- a/src/qtpromise/qpromise_p.h
+++ b/src/qtpromise/qpromise_p.h
@@ -52,7 +52,7 @@ static void qtpromise_defer(F&& f, const QPointer<QThread>& thread)
     {
         Event(FType&& f) : QEvent{QEvent::None}, m_f{std::move(f)} { }
         Event(const FType& f) : QEvent{QEvent::None}, m_f{f} { }
-        ~Event() { m_f(); }
+        ~Event() override { m_f(); }
         FType m_f;
     };
 

--- a/src/qtpromise/qpromise_p.h
+++ b/src/qtpromise/qpromise_p.h
@@ -113,7 +113,7 @@ public:
 
     PromiseError() { }
     PromiseError(const std::exception_ptr& exception) : m_data{exception} { }
-    void rethrow() const { std::rethrow_exception(m_data); }
+    [[ noreturn ]] void rethrow() const { std::rethrow_exception(m_data); }
     bool isNull() const { return m_data == nullptr; }
 
 private:

--- a/src/qtpromise/qpromise_p.h
+++ b/src/qtpromise/qpromise_p.h
@@ -113,7 +113,7 @@ public:
 
     PromiseError() { }
     PromiseError(const std::exception_ptr& exception) : m_data{exception} { }
-    [[ noreturn ]] void rethrow() const { std::rethrow_exception(m_data); }
+    Q_NORETURN void rethrow() const { std::rethrow_exception(m_data); }
     bool isNull() const { return m_data == nullptr; }
 
 private:

--- a/src/qtpromise/qpromise_p.h
+++ b/src/qtpromise/qpromise_p.h
@@ -329,8 +329,8 @@ struct PromiseCatcher
         return [=](const PromiseError& error) {
             try {
                 error.rethrow();
-            } catch (const TArg& error) {
-                PromiseDispatch<ResType>::call(resolve, reject, handler, error);
+            } catch (const TArg& argError) {
+                PromiseDispatch<ResType>::call(resolve, reject, handler, argError);
             } catch (...) {
                 reject(std::current_exception());
             }

--- a/src/qtpromise/qpromiseglobal.h
+++ b/src/qtpromise/qpromiseglobal.h
@@ -113,4 +113,14 @@ struct ArgsOf<R (T::*)(Args...) const volatile> : public ArgsTraits<Args...>
 
 } // namespace QtPromisePrivate
 
+
+// qtpromise still supports MSVC 2013 on CI/CD
+// -> MSVC 2013 does not support N2761, hence we need to wrap the noreturn attribute
+#if defined(_MSVC) &&  (_MSVC <= 1800)
+#define NO_RETURN
+#else
+#define NO_RETURN [[ noreturn ]]
+#endif
+
+
 #endif // QTPROMISE_QPROMISEGLOBAL_H

--- a/src/qtpromise/qpromiseglobal.h
+++ b/src/qtpromise/qpromiseglobal.h
@@ -113,14 +113,4 @@ struct ArgsOf<R (T::*)(Args...) const volatile> : public ArgsTraits<Args...>
 
 } // namespace QtPromisePrivate
 
-
-// qtpromise still supports MSVC 2013 on CI/CD
-// -> MSVC 2013 does not support N2761, hence we need to wrap the noreturn attribute
-#if defined(_MSVC) &&  (_MSVC <= 1800)
-#define NO_RETURN
-#else
-#define NO_RETURN [[ noreturn ]]
-#endif
-
-
 #endif // QTPROMISE_QPROMISEGLOBAL_H


### PR DESCRIPTION
```
In file included from xxx.cpp:19:
In file included from /home/ssp/src/qtpromise/include/QtPromise:11:
In file included from /home/ssp/src/qtpromise/include/../src/qtpromise/qpromise.h:11:
/home/ssp/src/qtpromise/include/../src/qtpromise/qpromise_p.h:116:26: warning: function 'rethrow' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
    void rethrow() const { std::rethrow_exception(m_data); }
                         ^
/home/ssp/src/qtpromise/include/../src/qtpromise/qpromise_p.h:55:9: warning: '~Event' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
        ~Event() { m_f(); }
        ^
/home/ssp/src/qtpromise/include/../src/qtpromise/qpromise_p.h:51:12: note: in instantiation of member class 'Event' requested here
    struct Event : public QEvent
           ^
/home/ssp/src/qtpromise/include/../src/qtpromise/qpromise_p.h:542:13: note: in instantiation of function template specialization 'QtPromisePrivate::qtpromise_defer<const std::function<void ()> &>' requested here
            qtpromise_defer(handler.second, handler.first);
            ^
/qt/5.15.1/gcc_64/include/QtCore/qcoreevent.h:299:13: note: overridden virtual function is here
    virtual ~QEvent();
            ^

```