### PR TITLE
Ignore fulfillment value by constructing QPromise<void> from QPromise<U>&&

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ add_definitions(
     -DQT_NO_KEYWORDS
 )
 
+option(DISABLE_VOID_FROM_U "Disable QPromise<void>(QPromise<U>&&) conversion" OFF)
+if (DISABLE_VOID_FROM_U)
+    add_definitions(-DQTPROMISE_DISABLE_VOID_FROM_U)
+endif()
+
 # https://github.com/simonbrunel/qtpromise/issues/10
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

--- a/docs/qtpromise/helpers/connect.md
+++ b/docs/qtpromise/helpers/connect.md
@@ -88,4 +88,9 @@ private:
 };
 ```
 
+::: warning IMPORTANT
+The conversion to `QtPromise<void>` is not supported on MSVC 2013. 
+:::
+
+
 See also the [`Qt Signals`](../qtsignals.md) section for more examples.

--- a/docs/qtpromise/qpromise/constructor.md
+++ b/docs/qtpromise/qpromise/constructor.md
@@ -81,3 +81,8 @@ QPromise<void> p = QPromise<int>{[](const QPromiseResolve<int>& resolve, const Q
     resolve(42);
 });
 ```
+
+::: warning IMPORTANT
+The conversion to `QtPromise<void>` is not supported on MSVC 2013. 
+:::
+

--- a/docs/qtpromise/qpromise/constructor.md
+++ b/docs/qtpromise/qpromise/constructor.md
@@ -68,3 +68,16 @@ promise.fail([]() {
     // { ... }
 })
 ```
+
+## Conversion to `QPromise<void>`
+
+*Since: 0.7.0*
+
+A `QPromise<void>` can be constructed from a non-void promise, if the fulfillment value needs to be
+ignored:
+
+```cpp
+QPromise<void> p = QPromise<int>{[](const QPromiseResolve<int>& resolve, const QPromiseReject<int>& reject) {
+    resolve(42);
+});
+```

--- a/docs/qtpromise/qtsignals.md
+++ b/docs/qtpromise/qtsignals.md
@@ -46,6 +46,10 @@ output.then([]() {
 });
 ```
 
+::: warning IMPORTANT
+The conversion to `QtPromise<void>` is not supported on MSVC 2013. 
+:::
+
 ::: tip NOTE
 QtPromise currently only supports single argument signals, which means that only the first argument
 is used to fulfill or reject the connected promise, other arguments being ignored.

--- a/docs/qtpromise/qtsignals.md
+++ b/docs/qtpromise/qtsignals.md
@@ -35,6 +35,17 @@ output.then([]() {
 });
 ```
 
+Optionally, a signal with an argument can be converted to `QPromise<void>`:
+
+```cpp
+// [signal] Object::finished(const QByteArray&)
+QPromise<void> output = QtPromise::connect(obj, &QObject::finished);
+
+output.then([]() {
+    // {...}
+});
+```
+
 ::: tip NOTE
 QtPromise currently only supports single argument signals, which means that only the first argument
 is used to fulfill or reject the connected promise, other arguments being ignored.

--- a/src/qtpromise/qpromise.h
+++ b/src/qtpromise/qpromise.h
@@ -33,6 +33,9 @@ public:
              typename std::enable_if<QtPromisePrivate::ArgsOf<F>::count != 1, int>::type = 0>
     inline QPromiseBase(F resolver);
 
+    template<typename U, typename std::enable_if<!std::is_same<T, U>::value, int>::type = 0>
+    inline QPromiseBase(QPromise<U>&& other);
+
     QPromiseBase(const QPromiseBase<T>& other) : m_d{other.m_d} { }
     QPromiseBase(const QPromise<T>& other) : m_d{other.m_d} { }
     QPromiseBase(QPromiseBase<T>&& other) Q_DECL_NOEXCEPT { swap(other); }
@@ -99,6 +102,7 @@ protected:
     friend struct QtPromisePrivate::PromiseFulfill<QPromise<T>>;
     friend class QtPromisePrivate::PromiseResolver<T>;
     friend struct QtPromisePrivate::PromiseInspect;
+    friend class QPromiseBase<void>;
 
     QExplicitlySharedDataPointer<QtPromisePrivate::PromiseData<T>> m_d;
 };

--- a/src/qtpromise/qpromise.h
+++ b/src/qtpromise/qpromise.h
@@ -33,7 +33,7 @@ public:
              typename std::enable_if<QtPromisePrivate::ArgsOf<F>::count != 1, int>::type = 0>
     inline QPromiseBase(F resolver);
 
-    template<typename U, typename std::enable_if<!std::is_same<T, U>::value, int>::type = 0>
+    template<typename U>
     inline QPromiseBase(QPromise<U>&& other);
 
     QPromiseBase(const QPromiseBase<T>& other) : m_d{other.m_d} { }

--- a/src/qtpromise/qpromise.h
+++ b/src/qtpromise/qpromise.h
@@ -33,8 +33,10 @@ public:
              typename std::enable_if<QtPromisePrivate::ArgsOf<F>::count != 1, int>::type = 0>
     inline QPromiseBase(F resolver);
 
+#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
     template<typename U>
     inline QPromiseBase(QPromise<U>&& other);
+#endif // QTPROMISE_SUPPORT_VOID_FROM_U
 
     QPromiseBase(const QPromiseBase<T>& other) : m_d{other.m_d} { }
     QPromiseBase(const QPromise<T>& other) : m_d{other.m_d} { }

--- a/src/qtpromise/qpromise.inl
+++ b/src/qtpromise/qpromise.inl
@@ -47,10 +47,11 @@ inline QPromiseBase<T>::QPromiseBase(F callback) : m_d{new QtPromisePrivate::Pro
     }
 }
 
+#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
 template<>
 template<typename U>
 inline QPromiseBase<void>::QPromiseBase(QPromise<U>&& other)
-    : QPromiseBase<void>(
+    : QPromiseBase<void>{
         [=](const QPromiseResolve<void>& resolve, const QPromiseReject<void>& reject) {
             other
                 .then([=]() {
@@ -59,8 +60,9 @@ inline QPromiseBase<void>::QPromiseBase(QPromise<U>&& other)
                 .fail([=]() {
                     reject(other.m_d->error());
                 });
-        })
+        }}
 { }
+#endif // QTPROMISE_SUPPORT_VOID_FROM_U
 
 template<typename T>
 template<typename TFulfilled, typename TRejected>

--- a/src/qtpromise/qpromise.inl
+++ b/src/qtpromise/qpromise.inl
@@ -47,6 +47,21 @@ inline QPromiseBase<T>::QPromiseBase(F callback) : m_d{new QtPromisePrivate::Pro
     }
 }
 
+template<>
+template<typename U, typename std::enable_if<!std::is_same<void, U>::value, int>::type>
+inline QPromiseBase<void>::QPromiseBase(QPromise<U>&& other)
+    : QPromiseBase<void>{
+        [=](const QPromiseResolve<void>& resolve, const QPromiseReject<void>& reject) {
+            other
+                .then([=]() {
+                    resolve();
+                })
+                .fail([=]() {
+                    reject(other.m_d->error());
+                });
+        }}
+{ }
+
 template<typename T>
 template<typename TFulfilled, typename TRejected>
 inline typename QtPromisePrivate::PromiseHandler<T, TFulfilled>::Promise

--- a/src/qtpromise/qpromise.inl
+++ b/src/qtpromise/qpromise.inl
@@ -48,7 +48,7 @@ inline QPromiseBase<T>::QPromiseBase(F callback) : m_d{new QtPromisePrivate::Pro
 }
 
 template<>
-template<typename U, typename std::enable_if<!std::is_same<void, U>::value, int>::type>
+template<typename U>
 inline QPromiseBase<void>::QPromiseBase(QPromise<U>&& other)
     : QPromiseBase<void>{
         [=](const QPromiseResolve<void>& resolve, const QPromiseReject<void>& reject) {

--- a/src/qtpromise/qpromise.inl
+++ b/src/qtpromise/qpromise.inl
@@ -50,7 +50,7 @@ inline QPromiseBase<T>::QPromiseBase(F callback) : m_d{new QtPromisePrivate::Pro
 template<>
 template<typename U>
 inline QPromiseBase<void>::QPromiseBase(QPromise<U>&& other)
-    : QPromiseBase<void>{
+    : QPromiseBase<void>(
         [=](const QPromiseResolve<void>& resolve, const QPromiseReject<void>& reject) {
             other
                 .then([=]() {
@@ -59,7 +59,7 @@ inline QPromiseBase<void>::QPromiseBase(QPromise<U>&& other)
                 .fail([=]() {
                     reject(other.m_d->error());
                 });
-        }}
+        })
 { }
 
 template<typename T>

--- a/src/qtpromise/qpromiseglobal.h
+++ b/src/qtpromise/qpromiseglobal.h
@@ -114,6 +114,8 @@ struct ArgsOf<R (T::*)(Args...) const volatile> : public ArgsTraits<Args...>
 } // namespace QtPromisePrivate
 
 // Enable constructor QPromise<void>(QPromise<U>&&)
-#define QTPROMISE_SUPPORT_VOID_FROM_U (!defined(_MSC_VER) || _MSC_VER > 1800)
+#if (!defined(QTPROMISE_DISABLE_VOID_FROM_U) && (!defined(_MSC_VER) || _MSC_VER > 1800))
+#    define QTPROMISE_SUPPORT_VOID_FROM_U
+#endif
 
 #endif // QTPROMISE_QPROMISEGLOBAL_H

--- a/src/qtpromise/qpromiseglobal.h
+++ b/src/qtpromise/qpromiseglobal.h
@@ -113,4 +113,7 @@ struct ArgsOf<R (T::*)(Args...) const volatile> : public ArgsTraits<Args...>
 
 } // namespace QtPromisePrivate
 
+// Enable constructor QPromise<void>(QPromise<U>&&)
+#define QTPROMISE_SUPPORT_VOID_FROM_U (!defined(_MSC_VER) || _MSC_VER > 1800)
+
 #endif // QTPROMISE_QPROMISEGLOBAL_H

--- a/tests/auto/qtpromise/helpers/tst_connect.cpp
+++ b/tests/auto/qtpromise/helpers/tst_connect.cpp
@@ -35,8 +35,10 @@ private Q_SLOTS:
     void rejectTwoSendersManyArgs();
     void rejectTwoSendersDestroyed();
 
+#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
     void resolveImplicitlyConvertedToPromiseVoid();
     void rejectImplicitlyConvertedToPromiseVoid();
+#endif
 };
 
 QTEST_MAIN(tst_helpers_connect)
@@ -217,6 +219,7 @@ void tst_helpers_connect::rejectTwoSendersDestroyed()
     QCOMPARE(waitForValue(p, -1, 42), 42);
 }
 
+#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
 void tst_helpers_connect::resolveImplicitlyConvertedToPromiseVoid()
 {
     Object sender;
@@ -252,3 +255,4 @@ void tst_helpers_connect::rejectImplicitlyConvertedToPromiseVoid()
     QCOMPARE(p.isPending(), true);
     QCOMPARE(waitForError(p, -1), 42);
 }
+#endif // QTPROMISE_SUPPORT_VOID_FROM_U

--- a/tests/auto/qtpromise/helpers/tst_connect.cpp
+++ b/tests/auto/qtpromise/helpers/tst_connect.cpp
@@ -35,10 +35,11 @@ private Q_SLOTS:
     void rejectTwoSendersManyArgs();
     void rejectTwoSendersDestroyed();
 
-#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
+    // QTPROMISE_SUPPORT_VOID_FROM_U
+    // The methods declarations cannot be excluded because they are processed by moc anyway.
+    // See https://bugreports.qt.io/browse/QTBUG-81536
     void resolveImplicitlyConvertedToPromiseVoid();
     void rejectImplicitlyConvertedToPromiseVoid();
-#endif
 };
 
 QTEST_MAIN(tst_helpers_connect)
@@ -219,9 +220,9 @@ void tst_helpers_connect::rejectTwoSendersDestroyed()
     QCOMPARE(waitForValue(p, -1, 42), 42);
 }
 
-#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
 void tst_helpers_connect::resolveImplicitlyConvertedToPromiseVoid()
 {
+#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
     Object sender;
 
     auto helper = [&]() -> QPromise<void> {
@@ -236,10 +237,12 @@ void tst_helpers_connect::resolveImplicitlyConvertedToPromiseVoid()
     Q_STATIC_ASSERT((std::is_same<decltype(p), QPromise<void>>::value));
     QCOMPARE(p.isPending(), true);
     QCOMPARE(waitForValue(p, -1, 42), 42);
+#endif
 }
 
 void tst_helpers_connect::rejectImplicitlyConvertedToPromiseVoid()
 {
+#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
     Object sender;
 
     auto helper = [&]() -> QPromise<void> {
@@ -254,5 +257,5 @@ void tst_helpers_connect::rejectImplicitlyConvertedToPromiseVoid()
     Q_STATIC_ASSERT((std::is_same<decltype(p), QPromise<void>>::value));
     QCOMPARE(p.isPending(), true);
     QCOMPARE(waitForError(p, -1), 42);
-}
 #endif // QTPROMISE_SUPPORT_VOID_FROM_U
+}

--- a/tests/auto/qtpromise/qpromise/tst_construct.cpp
+++ b/tests/auto/qtpromise/qpromise/tst_construct.cpp
@@ -40,13 +40,14 @@ private Q_SLOTS:
     void connectAndResolve();
     void connectAndReject();
 
-#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
+    // QTPROMISE_SUPPORT_VOID_FROM_U
+    // The methods declarations cannot be excluded because they are processed by moc anyway.
+    // See https://bugreports.qt.io/browse/QTBUG-81536
     void resolveAsyncOneArgToVoid();
     void resolveOneArgToVoid();
     void rejectAsyncOneArgToVoid();
     void rejectOneArgToVoid();
     void implicitCastToVoidPromise();
-#endif
 };
 
 QTEST_MAIN(tst_qpromise_construct)
@@ -341,9 +342,9 @@ void tst_qpromise_construct::connectAndReject()
     QCOMPARE(wptr.use_count(), 0l);
 }
 
-#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
 void tst_qpromise_construct::resolveAsyncOneArgToVoid()
 {
+#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
     auto p = QPromise<void>{QPromise<int>{[](const QPromiseResolve<int>& resolve) {
         QtPromisePrivate::qtpromise_defer([=]() {
             resolve(42);
@@ -353,19 +354,23 @@ void tst_qpromise_construct::resolveAsyncOneArgToVoid()
     QVERIFY(p.isPending());
     QCOMPARE(waitForValue(p, -1, 42), 42);
     QVERIFY(p.isFulfilled());
+#endif // QTPROMISE_SUPPORT_VOID_FROM_U
 }
 
 void tst_qpromise_construct::resolveOneArgToVoid()
 {
+#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
     auto p = QPromise<void>{QtPromise::resolve(42)};
 
     QVERIFY(p.isPending());
     QCOMPARE(waitForValue(p, -1, 42), 42);
     QVERIFY(p.isFulfilled());
+#endif // QTPROMISE_SUPPORT_VOID_FROM_U
 }
 
 void tst_qpromise_construct::rejectAsyncOneArgToVoid()
 {
+#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
     auto p = QPromise<void>{
         QPromise<int>{[](const QPromiseResolve<int>&, const QPromiseReject<int>& reject) {
             QtPromisePrivate::qtpromise_defer([=]() {
@@ -376,10 +381,12 @@ void tst_qpromise_construct::rejectAsyncOneArgToVoid()
     QVERIFY(p.isPending());
     QCOMPARE(waitForError(p, QString{}), QString{"foo"});
     QVERIFY(p.isRejected());
+#endif // QTPROMISE_SUPPORT_VOID_FROM_U
 }
 
 void tst_qpromise_construct::rejectOneArgToVoid()
 {
+#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
     auto p = QPromise<void>{
         QPromise<int>{[](const QPromiseResolve<int>&, const QPromiseReject<int>& reject) {
             reject(QString{"foo"});
@@ -388,10 +395,12 @@ void tst_qpromise_construct::rejectOneArgToVoid()
     QVERIFY(p.isPending());
     QCOMPARE(waitForError(p, QString{}), QString{"foo"});
     QVERIFY(p.isRejected());
+#endif // QTPROMISE_SUPPORT_VOID_FROM_U
 }
 
 void tst_qpromise_construct::implicitCastToVoidPromise()
 {
+#ifdef QTPROMISE_SUPPORT_VOID_FROM_U
     auto helper = []() -> QPromise<void> {
         return QtPromise::resolve(42);
     };
@@ -402,5 +411,5 @@ void tst_qpromise_construct::implicitCastToVoidPromise()
     QVERIFY(p.isPending());
     QCOMPARE(waitForValue(p, -1, 42), 42);
     QVERIFY(p.isFulfilled());
-}
 #endif // QTPROMISE_SUPPORT_VOID_FROM_U
+}


### PR DESCRIPTION
Hey Simon, 

I've come across the following issue a couple of times already when introducing QtPromise API to existing classes in a project and when writing QtPromise adapter classes for Qt APIs. 

Sometimes I don't want to expose the fulfillment value to the clients of the class due to various reasons---hiding a further dependency or an implementation detail, or "misusing" an existing Qt signal with an argument to indicate the promise fulfillment---so I'd like to have a `QPromise<void>` as the return value but internally a valued promise is created. So I have to use a bit of a trick: 

```cpp
QPromise<void> Worker::executeAsync()
{
    auto p = QtPromise::connect(this, Worker::finishedWithInt, Worker::errorOccurred);
    execute();
    return QPromise<void>{[=](const QPromiseResolve<void>& resolve, const QPromiseReject<void>& reject) {
        p.then([](int i) {
            Q_UNUSED(i)
            resolve();
        }).fail([]() {
            reject();
        });
    }};
}
```

Apart from having a fair amount of boilerplate, I couldn't find a possibility to catch reject errors which could still be of interest to class's clients. 

So I've made a patch suggestion that adds a `PromiseBase<void>(PromiseBase<U>&&)` constructor to drop any fulfillment value by wrapping the nested promise with a `QPromise<void>`. So the code above can be rewritten as follows:

```cpp
QPromise<void> Worker::executeAsync()
{
    auto p = QtPromise::connect(this, Worker::finishedWithInt, Worker::errorOccurred);
    execute();
    return p;
}
```

Additionally, the patch handles the rejection of the nested promise and forwards the error to the `QPromise<void>`.

Cheers