### PR TITLE
Fix GCC warning maybe-uninitialized for PromiseValue<T> constructor

### DIFF
--- a/src/qtpromise/qpromise_p.h
+++ b/src/qtpromise/qpromise_p.h
@@ -20,6 +20,8 @@
 #include <QtCore/QVariant>
 #include <QtCore/QVector>
 
+#include <memory>
+
 namespace QtPromise {
 
 template<typename T>
@@ -92,13 +94,13 @@ class PromiseValue
 {
 public:
     PromiseValue() { }
-    PromiseValue(const T& data) : m_data(QSharedPointer<T>::create(data)) { }
-    PromiseValue(T&& data) : m_data(QSharedPointer<T>::create(std::forward<T>(data))) { }
-    bool isNull() const { return m_data.isNull(); }
+    PromiseValue(const T& data) : m_data(std::make_shared<T>(data)) { }
+    PromiseValue(T&& data) : m_data(std::make_shared<T>(std::forward<T>(data))) { }
+    bool isNull() const { return m_data == nullptr; }
     const T& data() const { return *m_data; }
 
 private:
-    QSharedPointer<T> m_data;
+    std::shared_ptr<T> m_data;
 };
 
 class PromiseError


### PR DESCRIPTION
Use `std::shared_ptr` for `PromiseValue<T>::m_data` instead of `QSharedPoitner<T>`

In optimized builds (such as -O2) GCC emits "maybe-uninitialized" warning for `QSharedPointer<T>::d`.  This happens only for optimized builds because that is when GCC tracks lifetimes[1]. In a project with lots of QtPromise uses this produces a heap of bogus warnings. This warning has been previously reported to a Qt team, but they're confident it is a compiler bug[2][3]. However, this is a second time and issue raised with `QSharedPointer` and warnings to it. The first time it was addressed here: https://github.com/simonbrunel/qtpromise/pull/34.

<details><summary>GCC output</summary>
<p>

```
[95/111] Building CXX object tests/auto/qtpromise/warnings/CMakeFiles/qtpromise.tests.auto.warnings.dir/tst_warnings.cpp.o
FAILED: tests/auto/qtpromise/warnings/CMakeFiles/qtpromise.tests.auto.warnings.dir/tst_warnings.cpp.o 
/usr/bin/c++ -DQT_CONCURRENT_LIB -DQT_CORE_LIB -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_NO_KEYWORDS -DQT_TESTCASE_BUILDDIR=\"/home/joe/programming/qtpromise/build\" -DQT_TESTLIB_LIB -I/home/joe/programming/qtpromise/build/tests/auto/qtpromise/warnings/qtpromise.tests.auto.warnings_autogen/include -I/home/joe/programming/qtpromise/include -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtConcurrent -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -isystem /usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -isystem /usr/include/x86_64-linux-gnu/qt5/QtTest -std=gnu++11 -Werror -Wpedantic -Wall -Wextra -Wconversion -Wdouble-promotion -Wformat=2 -Wlogical-op -Wmissing-noreturn -Wold-style-cast -Wsign-conversion -Wswitch-default -Wunused-local-typedefs -pedantic-errors -Wduplicated-cond -Wduplicated-branches -fprofile-arcs -ftest-coverage -O0 -g -O2 -Werror=maybe-uninitialized -fPIC -MD -MT tests/auto/qtpromise/warnings/CMakeFiles/qtpromise.tests.auto.warnings.dir/tst_warnings.cpp.o -MF tests/auto/qtpromise/warnings/CMakeFiles/qtpromise.tests.auto.warnings.dir/tst_warnings.cpp.o.d -o tests/auto/qtpromise/warnings/CMakeFiles/qtpromise.tests.auto.warnings.dir/tst_warnings.cpp.o -c /home/joe/programming/qtpromise/tests/auto/qtpromise/warnings/tst_warnings.cpp
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qsharedpointer.h:48,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/qdebug.h:54,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/qcborcommon.h:45,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/qcborvalue.h:45,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/qcborarray.h:43,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/QtCore:38,
                 from /usr/include/x86_64-linux-gnu/qt5/QtConcurrent/QtConcurrentDepends:3,
                 from /usr/include/x86_64-linux-gnu/qt5/QtConcurrent/QtConcurrent:3,
                 from /home/joe/programming/qtpromise/tests/auto/qtpromise/warnings/tst_warnings.cpp:8:
In member function ‘void QSharedPointer<T>::deref() [with T = int]’,
    inlined from ‘QSharedPointer<T>::~QSharedPointer() [with T = int]’ at /usr/include/x86_64-linux-gnu/qt5/QtCore/qsharedpointer_impl.h:316:30,
    inlined from ‘static QSharedPointer<T> QSharedPointer<T>::create(Args&& ...) [with Args = {int}; T = int]’ at /usr/include/x86_64-linux-gnu/qt5/QtCore/qsharedpointer_impl.h:453:5,
    inlined from ‘QtPromisePrivate::PromiseValue<T>::PromiseValue(T&&) [with T = int]’ at /home/joe/programming/qtpromise/include/../src/qtpromise/qpromise_p.h:96:30,
    inlined from ‘void QtPromisePrivate::PromiseData<T>::resolve(V&&) [with V = int; T = int]’ at /home/joe/programming/qtpromise/include/../src/qtpromise/qpromise_p.h:511:17,
    inlined from ‘void QtPromisePrivate::PromiseResolver<T>::resolve(V&&) [with V = int; T = int]’ at /home/joe/programming/qtpromise/include/../src/qtpromise/qpromiseresolver.h:62:34:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qsharedpointer_impl.h:459:12: error: ‘<unnamed>.QtPromisePrivate::PromiseValue<int>::m_data.QSharedPointer<int>::d’ may be used uninitialized [-Werror=maybe-uninitialized]
  459 |     { deref(d); }
      |       ~~~~~^~~
In file included from /home/joe/programming/qtpromise/include/../src/qtpromise/qpromise.h:12,
                 from /home/joe/programming/qtpromise/include/QtPromise:11,
                 from /home/joe/programming/qtpromise/tests/auto/qtpromise/warnings/tst_warnings.cpp:9:
/home/joe/programming/qtpromise/include/../src/qtpromise/qpromise_p.h: In member function ‘void QtPromisePrivate::PromiseResolver<T>::resolve(V&&) [with V = int; T = int]’:
/home/joe/programming/qtpromise/include/../src/qtpromise/qpromise_p.h:511:17: note: ‘<anonymous>’ declared here
  511 |         m_value = PromiseValue<T>{std::forward<V>(value)};
      |         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
[103/111] Building CXX object tests/auto/qtpromise/qpromise/CMakeFiles/qtpromise.tests.auto.qpromise.reduce.dir/tst_reduce.cpp.o
ninja: build stopped: subcommand failed.
```

</p>
</details> 

[1] https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wmaybe-uninitialized
[2] https://bugreports.qt.io/browse/QTBUG-14637
[3] https://bugreports.qt.io/browse/QTBUG-77641